### PR TITLE
Add jsx-runtime and jsx-dev-runtime exports

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,11 @@
 
   "name": "@wormblossom/macromania",
   "version": "1.0.1",
-  "exports": "./mod.ts",
+  "exports": {
+    ".": "./mod.ts",
+    "./jsx-runtime": "./mod.ts",
+    "./jsx-dev-runtime": "./mod.ts"
+  },
 
   "imports": {
     "@aljoschameyer/loggingutils": "jsr:@aljoscha-meyer/logging-utils@^1.0.0",


### PR DESCRIPTION
I believe this all we should need to do to *work around* the issue in https://github.com/jsr-io/jsr/issues/1098

Basically: when JSR looks at the `compilerOptions.jsxImportSource` field **it doesn't seem to resolve it using the `imports` field**. 

By adding `exports` for `jsx-runtime` and `jsx-dev-runtime` to macromania, we *should* be able fix that.

Added bonus: setting up macromania becomes simpler:

```
compilerOptions: {
  "jsxImportSource": "@wormblossom/macromania",
}
```